### PR TITLE
Implement Basic Cgroups Management for Resource Isolation

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -64,3 +64,12 @@ func (m *Manager) applyV2(cpuLimit float64, memoryLimit string) error {
 
 	return nil
 }
+
+func (m *Manager) AddProcess(pid int) error {
+	if cgroupsV2 {
+		cgroupPath := filepath.Join("/sys/fs/cgroup", m.Path)
+		return writeFile(filepath.Join(cgroupPath, "cgroup.procs"), strconv.Itoa(pid))
+	}
+
+	return nil
+}

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -73,3 +73,10 @@ func (m *Manager) AddProcess(pid int) error {
 
 	return nil
 }
+
+func (m *Manager) Destroy() error {
+	if cgroupsV2 {
+		return os.RemoveAll(filepath.Join("/sys/fs/cgroup", m.Path))
+	}
+	return nil
+}

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -1,6 +1,11 @@
 package cgroups
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
 
 var cgroupsV2 = false
 
@@ -19,4 +24,43 @@ func NewManager(path string) *Manager {
 	return &Manager{
 		Path: path,
 	}
+}
+
+func (m *Manager) applyV2(cpuLimit float64, memoryLimit string) error {
+	// Integration cgroup v2 path
+	cgroupPath := filepath.Join("/sys/fs/cgroup", m.Path)
+	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup directory: %v", err)
+	}
+
+	// activate controller
+	if err := writeFile(filepath.Join(cgroupPath, "cgroup.subtree_control"), "+cpu +memory"); err != nil {
+		return err
+	}
+
+	// set CPU limit
+	period := 100000
+	quota := int(float64(period) * cpuLimit)
+	if quota < 1000 {
+		quota = 1000 // minimum quota
+	}
+
+	// write CPU limit file
+	if err := writeFile(filepath.Join(cgroupPath, "cpu.max"),
+		fmt.Sprintf("%d %d", quota, period)); err != nil {
+		return err
+	}
+
+	memoryBytes, err := parseMemoryLimit(memoryLimit)
+	if err != nil {
+		return err
+	}
+
+	// write memory limit file
+	if err := writeFile(filepath.Join(cgroupPath, "memory.max"),
+		strconv.FormatInt(memoryBytes, 10)); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -1,0 +1,22 @@
+package cgroups
+
+import "os"
+
+var cgroupsV2 = false
+
+func init() {
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err == nil {
+		cgroupsV2 = true
+	}
+}
+
+type Manager struct {
+	Path string // cgroup path
+}
+
+// create new cgroups manager
+func NewManager(path string) *Manager {
+	return &Manager{
+		Path: path,
+	}
+}

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -26,6 +26,13 @@ func NewManager(path string) *Manager {
 	}
 }
 
+func (m *Manager) Apply(cpuLimit float64, memoryLimit string) error {
+	if cgroupsV2 {
+		return m.applyV2(cpuLimit, memoryLimit)
+	}
+	return m.applyV1(cpuLimit, memoryLimit)
+}
+
 func (m *Manager) applyV2(cpuLimit float64, memoryLimit string) error {
 	// Integration cgroup v2 path
 	cgroupPath := filepath.Join("/sys/fs/cgroup", m.Path)
@@ -65,10 +72,57 @@ func (m *Manager) applyV2(cpuLimit float64, memoryLimit string) error {
 	return nil
 }
 
+// cgroups v1
+func (m *Manager) applyV1(cpuLimit float64, memoryLimit string) error {
+	cpuPath := filepath.Join("/sys/fs/cgroup/cpu", m.Path)
+	if err := os.MkdirAll(cpuPath, 0755); err != nil {
+		return fmt.Errorf("failed to create CPU cgroup directory: %v", err)
+	}
+
+	period := 100000
+	quota := int(float64(period) * cpuLimit)
+	if quota < 1000 {
+		quota = 1000 // minimum 1ms
+	}
+
+	// cpu limit
+	if err := writeFile(filepath.Join(cpuPath, "cpu.cfs_period_us"), strconv.Itoa(period)); err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(cpuPath, "cpu.cfs_quota_us"), strconv.Itoa(quota)); err != nil {
+		return err
+	}
+
+	// memory limit
+	memoryPath := filepath.Join("/sys/fs/cgroup/memory", m.Path)
+	if err := os.MkdirAll(memoryPath, 0755); err != nil {
+		return fmt.Errorf("failed to create memory cgroup directory: %v", err)
+	}
+
+	memoryBytes, err := parseMemoryLimit(memoryLimit)
+	if err != nil {
+		return err
+	}
+
+	if err := writeFile(filepath.Join(memoryPath, "memory.limit_in_bytes"), strconv.FormatInt(memoryBytes, 10)); err != nil {
+		return err
+	}
+	return err
+}
+
 func (m *Manager) AddProcess(pid int) error {
 	if cgroupsV2 {
 		cgroupPath := filepath.Join("/sys/fs/cgroup", m.Path)
 		return writeFile(filepath.Join(cgroupPath, "cgroup.procs"), strconv.Itoa(pid))
+	}
+
+	// v1
+	subsystems := []string{"cpu", "memory"}
+	for _, sys := range subsystems {
+		path := filepath.Join("/sys/fs/cgroup", sys, m.Path)
+		if err := writeFile(filepath.Join(path, "cgroup.procs"), strconv.Itoa(pid)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -78,5 +132,15 @@ func (m *Manager) Destroy() error {
 	if cgroupsV2 {
 		return os.RemoveAll(filepath.Join("/sys/fs/cgroup", m.Path))
 	}
+
+	// v1
+	subsystems := []string{"cpu", "memory"}
+	for _, sys := range subsystems {
+		path := filepath.Join("/sys/fs/cgroup", sys, m.Path)
+		if err := os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/cgroups/utils.go
+++ b/pkg/cgroups/utils.go
@@ -1,0 +1,15 @@
+package cgroups
+
+import "os"
+
+func readFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func writeFile(path, data string) error {
+	return os.WriteFile(path, []byte(data), 0644)
+}

--- a/pkg/cgroups/utils.go
+++ b/pkg/cgroups/utils.go
@@ -1,6 +1,11 @@
 package cgroups
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
 
 func readFile(path string) (string, error) {
 	data, err := os.ReadFile(path)
@@ -12,4 +17,27 @@ func readFile(path string) (string, error) {
 
 func writeFile(path, data string) error {
 	return os.WriteFile(path, []byte(data), 0644)
+}
+
+func parseMemoryLimit(limit string) (int64, error) {
+	limit = strings.ToLower(limit)
+
+	var multiplier int64 = 1
+	if strings.HasSuffix(limit, "k") {
+		multiplier = 1024
+		limit = limit[:len(limit)-1]
+	} else if strings.HasSuffix(limit, "m") {
+		multiplier = 1024 * 1024
+		limit = limit[:len(limit)-1]
+	} else if strings.HasSuffix(limit, "g") {
+		multiplier = 1024 * 1024 * 1024
+		limit = limit[:len(limit)-1]
+	}
+
+	value, err := strconv.ParseInt(limit, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("Invalid memory limit format: %s", limit)
+	}
+
+	return value * multiplier, nil
 }


### PR DESCRIPTION
This PR implemented a fundamental cgroups package that enables resource isolation for containerized processes. It provides functionality to create cgroups, apply CPU and memory limits, add processes to these cgroups, and clean up the created cgroups.

The package supports both cgroups `v1` and `v2`, automatically detecting the active version on the system during initialization. The implementation handles the different file system structures and control mechanisms of each version.

### Key Features
- Automatically identifies whether the system is using cgroups `v1` or `v2`
- Creates dedicated cgroup directories under the appropriate hierarchy (`/sys/fs/cgroup` for v2, `/sys/fs/cgroup/cpu` and `/sys/fs/cgroup/memory` for v1)
- Allows setting cpu/memory limits based on a fractional value.
- `AddProcess()` adds a given process ID (PID) to the managed cgroup. This ensures that the process is subject to the applied resource limits.
- `Destroy()` cleans up the created cgroup directories, removing the applied resource limits and isolation.

### Testing
This PR includes the basic implementation of the cgroups management functionality. Further testing will be required to ensure the correct application of resource limits and proper cleanup in various scenarios and under different system loads. Unit tests for the `parseMemoryLimit` function and integration tests exercising the full lifecycle of cgroup management should be added in subsequent PRs.